### PR TITLE
Write tests for the issue #535 fix.

### DIFF
--- a/tardis/io/config_reader.py
+++ b/tardis/io/config_reader.py
@@ -23,7 +23,7 @@ pp = pprint.PrettyPrinter(indent=4)
 
 logger = logging.getLogger(__name__)
 
-data_dir = os.path.join(tardis.__path__[0], 'data')
+data_dir = os.path.abspath(os.path.join(tardis.__path__[0], 'data'))
 
 default_config_definition_file = os.path.join(data_dir,
                                               'tardis_config_definition.yml')

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -358,6 +358,25 @@ def test_ascii_reader_exponential_law():
         assert_almost_equal(structure['mean_densities'][i].value,mdens)
         assert structure['mean_densities'][i].unit ==  u.Unit(expected_unit)
 
+class TestAbsoluteRelativeConfigFilePaths:
+    def setup(self):
+        self.original_cwd = os.getcwd()
+        self.config_filename = 'tardis_configv1_ascii_density_abund.yml'
+
+    def test_relative_config_path_same_dir(self):
+        os.chdir(data_path(''))
+        config = config_reader.Configuration.from_yaml(self.config_filename, test_parser=True)
+        os.chdir(self.original_cwd)
+
+    def test_relative_config_path_parent_dir(self):
+        os.chdir(os.path.join(data_path(''), os.path.pardir))
+        config_path = os.path.relpath(data_path(self.config_filename))
+        config = config_reader.Configuration.from_yaml(config_path, test_parser=True)
+        os.chdir(self.original_cwd)
+
+    def test_absolute_config_path(self):
+        config = config_reader.Configuration.from_yaml(os.path.abspath(data_path(self.config_filename)),
+                                                       test_parser=True)
 
 
 #write tests for inner and outer boundary indices

--- a/tardis/io/tests/test_config_reader.py
+++ b/tardis/io/tests/test_config_reader.py
@@ -1,6 +1,7 @@
 # tests for the config reader module
 from tardis.io import config_reader
 from astropy import units as u
+from contextlib import contextmanager
 import os
 import pytest
 import yaml
@@ -11,7 +12,20 @@ from tardis.util import parse_quantity
 
 def data_path(filename):
     data_dir = os.path.dirname(__file__)
-    return os.path.join(data_dir, 'data', filename)
+    return os.path.abspath(os.path.join(data_dir, 'data', filename))
+
+@contextmanager
+def change_cwd(directory):
+    # Function taken from:
+    # https://github.com/django/django/blob/18d962f2e6cc8829d60d6f6dfb3ee3855fa5362e/tests/test_runner/test_discover_runner.py
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    new_dir = os.path.join(current_dir, directory)
+    old_cwd = os.getcwd()
+    os.chdir(new_dir)
+    try:
+        yield
+    finally:
+        os.chdir(old_cwd)
 
 def test_config_namespace_attribute_test():
     namespace = config_reader.ConfigurationNameSpace({'param1':1})
@@ -360,19 +374,16 @@ def test_ascii_reader_exponential_law():
 
 class TestAbsoluteRelativeConfigFilePaths:
     def setup(self):
-        self.original_cwd = os.getcwd()
         self.config_filename = 'tardis_configv1_ascii_density_abund.yml'
 
     def test_relative_config_path_same_dir(self):
-        os.chdir(data_path(''))
-        config = config_reader.Configuration.from_yaml(self.config_filename, test_parser=True)
-        os.chdir(self.original_cwd)
+        with change_cwd(data_path('')):
+            config = config_reader.Configuration.from_yaml(self.config_filename, test_parser=True)
 
     def test_relative_config_path_parent_dir(self):
-        os.chdir(os.path.join(data_path(''), os.path.pardir))
-        config_path = os.path.relpath(data_path(self.config_filename))
-        config = config_reader.Configuration.from_yaml(config_path, test_parser=True)
-        os.chdir(self.original_cwd)
+        config_path = os.path.relpath(data_path(self.config_filename), data_path(os.path.pardir))
+        with change_cwd(data_path(os.path.pardir)):
+            config = config_reader.Configuration.from_yaml(config_path, test_parser=True)
 
     def test_absolute_config_path(self):
         config = config_reader.Configuration.from_yaml(os.path.abspath(data_path(self.config_filename)),


### PR DESCRIPTION
Wrote 3 tests, all of them use the `tardis_configv1_ascii_density_abund.yml` configuration file which uses external files for both the structure, and the abundances. Given that these files are specified as filenames without paths in the configuration, the following tests (which @yeganer proposed) should verify that the changes introduced in #543 work as expected.

Test if the config_reader can properly read the configuration when:
1. The working directory is the same as the configuration file and a filename without path is provided.
2. The working directory is the parent directory of the configuration file and a filename with a relative path is provided.
3. The working directory is whatever it was when py.test started and a filename with an absolute path is provided.

I used no asserts since pytest considers a test failed if an exception is raised while running it, and the config_reader would raise one if it could not find any of the files. Though this is something I'm not sure if I did right.
